### PR TITLE
Update project links

### DIFF
--- a/projects/index.md
+++ b/projects/index.md
@@ -7,20 +7,6 @@ title: Projects
 
 <div class=projects_gallery>
 <figure>
-    <a href="https://amsterdamcooperationlab.com/databank/">
-    <img src="{{ site.baseurl }}images/projects/Amsterdam-cooperation-databank-LARGE-300x132.png" class="projects_gallery__img" alt="Image 1">
-    </a>
-    <figcaption></figcaption>
-</figure>
-
-<figure>
-    <a href="https://www.civic-ai.nl/">
-    <img src="{{ site.baseurl }}images/projects/civic_ai_lab.png" class="projects_gallery__img" alt="Image 1">
-    </a>
-    <figcaption></figcaption>
-</figure>
-
-<figure>
     <a href="http://www.clariah.nl/">
     <img src="{{ site.baseurl }}images/projects/Clariah-300x83.png" class="projects_gallery__img" alt="Image 1">
     </a>
@@ -53,12 +39,6 @@ title: Projects
     <figcaption></figcaption>
 </figure>
 
-<figure>
-    <a href="https://www.narcis.nl/research/RecordID/OND1359681">
-    <img src="{{ site.baseurl }}images/projects/Maestrograph_thin-300x156.jpg" class="projects_gallery__img" alt="Image 1">
-    </a>
-    <figcaption></figcaption>
-</figure>
 
 <figure>
     <a href="https://muhai.univiu.org/">
@@ -71,35 +51,36 @@ title: Projects
 # Previous Projects #
 
 <ul>
-    <li><a href="http://www.risis.eu/" target="_blank" rel="noreferrer noopener">RISIS (Research Infrastructure for
-            Science and Innovation Studies)</a></li>
+    <li>RISIS (Research Infrastructure for
+            Science and Innovation Studies)</li>
     <li><a href="http://slidewiki.eu/">SlideWiki</a></li>
     <li><a href="http://www.understandinglanguagebymachines.org/a-quantum-model-of-text-understanding/" target="_blank"
             rel="noreferrer noopener">ULM-4 (Understanding Language by Machines 4)</a></li>
-    <li><a href="http://www.data2semantics.org/" target="_blank" rel="noreferrer noopener">Data2Semantics (COMMIT)</a>
+    <li>Data2Semantics (COMMIT)
     </li>
     <li><a href="http://eurecaproject.eu/" target="_blank" rel="noreferrer noopener">Eureca</a></li>
     <li><a href="http://www.openphacts.org/">Open PHACTS (Open Pharmacological Concepts Triple Store)</a></li>
     <li><a href="http://ldbc.eu/">LDBC</a></li>
     <li><a href="http://www.larkc.org/">LarKC (Large Knowledge Collider)</a></li>
     <li><a href="http://latc-project.eu/">LATC (Linked Open Data Around the Clock)</a></li>
-    <li><a href="http://aturstudio.com/wordnet/windex.php">Chinese WordNet</a></li>
-    <li><a href="http://www.sms-project.org/">SMS (Semantically Mapping Science)</a></li>
-    <li><a href="http://www.best-project.nl/">BEST</a></li>
-    <li><a href="http://www.few.vu.nl/soks/">SOKS (Self-Organising Knowledge Systems)</a></li>
+    <li>Chinese WordNet</li>
+    <li>SMS (Semantically Mapping Science)</li>
+    <li>BEST</li>
+    <li>SOKS (Self-Organising Knowledge Systems)</li>
     <li><a href="http://www.cs.vu.nl/STITCH/">STITCH (Semantic Interoperability To access Cultural Heritage)</a></li>
     <li><a href="http://knowledgeweb.semanticweb.org/">Knowledge Web</a></li>
-    <li><a href="http://www.openk.org/">OpenKnowledge</a></li>
+    <li>OpenKnowledge</li>
     <li><a href="http://www.protocure.org/">Protocure: Improving medical protocols by formal methods</a></li>
     <li><a href="http://www.sekt-project.com/">SEKT (Semantically Enabled Knowledge Technologies)</a></li>
-    <li><a href="http://www.swi.psy.uva.nl/projects/ibrow/home.html">IBROW: Intelligent Brokering Service for
+    <li><a href="http://projects.kmi.open.ac.uk/ibrow/">IBROW: Intelligent Brokering Service for
             Knowledge-Component Reuse on the World Wide Web</a></li>
-    <li><a href="http://www.ontoknowledge.org/">On-To-Knowledge: Content-driven knowledge management through evolving
-            ontologies</a></li>
-    <li><a href="http://www.ontoweb.org/">The OntoWeb Network</a></li>
+    <li>On-To-Knowledge: Content-driven knowledge management through evolving
+            ontologies</li>
+    <li>The OntoWeb Network</li>
     <li><a href="http://swap.semanticweb.org/">SWAP (Semantic Web And Peer-to-peer)</a></li>
-    <li><a href="http://wonderweb.semanticweb.org/">WonderWeb: Infrastructure for the Semantic Web</a></li>
-    <li><a href="http://www.i-catcher.org/">I-Catcher (Intensive-Care Access to Terminology &amp; Course of Health
-            Exploration and Retrieval)</a></li>
+    <li>WonderWeb: Infrastructure for the Semantic Web</li>
+    <li>I-Catcher (Intensive-Care Access to Terminology &amp; Course of Health
+            Exploration and Retrieval)</li>
+    <li><a href="https://www.narcis.nl/research/RecordID/OND1359681/">MaestroGraph: The Meaning and Structure of Very Large Knowledge Graphs</a></li>            
 </ul>
 


### PR DESCRIPTION
Below was the request from Frank:

1. can you remove CoDa and Civic Lab from lr.cs.vu.nl ? (we don't have a stake in these projects).
2. Also, can you move MaestroGraph to the list of Previous Projects.
3. Also can you go through the list of Previous Projects, and check the links? For the dead links (quite a few), can you remove the URL (but keep the item just as text? (Better no link then a dead link :latin_cross: )

I tried to find the new links that can possibly replace the dead links. I've only found one:
http://projects.kmi.open.ac.uk/ibrow/ can replace http://www.swi.psy.uva.nl/projects/ibrow/home.html for “IBROW: Intelligent Brokering Service for Knowledge-Component Reuse on the World Wide Web”